### PR TITLE
feat: added a fallback/development function to KinectManager to mock pressure

### DIFF
--- a/public/utils/KinectManager.js
+++ b/public/utils/KinectManager.js
@@ -10,6 +10,10 @@ class KinectManager {
     this.canvasWidth = null
     this.canvasHeight = null
     this.pushThreshold = 40
+    this.mockCircleX = 0
+    this.mockCircleY = 0
+    this.mockCircleMaxRadius = 0
+    this.mockPulsationPhase = 0
 
     this.socket.addEventListener('open', (_event) => {
       console.log('Connected to localhost:12345.')
@@ -28,6 +32,9 @@ class KinectManager {
   
     this.socket.addEventListener('close', (event) => {
       console.log("Socket closed", event)
+      setInterval(() => {
+        this.generateFakeFrame()
+      }, 100) // couldn't connect to the kinect, so we'll generate fake frames on a 100ms interval
     })
   }
 
@@ -56,6 +63,42 @@ class KinectManager {
     if (targetX < 0 || targetX >= this.frameWidth || targetY < 0 || targetY >= this.frameHeight) return 0
 
     return this.currentFrame[(targetY * this.frameWidth) + targetX] >= this.pushThreshold
+  }
+
+  generateFakeFrame() {
+    const fakeFrame = new Uint8Array(this.frameWidth * this.frameHeight)
+
+    if (this.mockPulsationPhase === 0) {
+      this.mockCircleX = Math.floor(Math.random() * this.frameWidth)
+      this.mockCircleY = Math.floor(Math.random() * this.frameHeight)
+      this.mockCircleMaxRadius = Math.floor(Math.random() * (100 - 50) + 50)
+    }
+
+    let radius
+    if (this.mockPulsationPhase <= this.mockCircleMaxRadius) {
+      radius = this.mockPulsationPhase
+    } else if (this.mockPulsationPhase <= 2 * this.mockCircleMaxRadius) {
+      radius = 2 * this.mockCircleMaxRadius - this.mockPulsationPhase
+    } else {
+      radius = 0
+    }
+
+    for (let x = 0; x < this.frameWidth; x++) {
+      for (let y = 0; y < this.frameHeight; y++) {
+        const distanceToCenterOfMockCircle = Math.sqrt((x - this.mockCircleX) ** 2 + (y - this.mockCircleY) ** 2)
+
+        fakeFrame[y * this.frameWidth + x] = distanceToCenterOfMockCircle < radius ? this.pushThreshold + 50 - distanceToCenterOfMockCircle : 0
+      }
+    }
+
+    this.mockPulsationPhase += 2
+    if (this.mockPulsationPhase > 2 * this.mockCircleMaxRadius) {
+      this.mockPulsationPhase = 0
+    }
+
+    this.currentFrame = fakeFrame
+    this.isRead = false
+    if (!this.firstFrameReceived) this.firstFrameReceived = true
   }
 }
 


### PR DESCRIPTION
Should work out of the box, and doesn't require any change in sketches already implementing the `KinectManager` class. When the sketch is not able to connect to the Python socket, the KinectManager class starts creating fake frames with white circles pulsating, simulating pressure on the canvas.